### PR TITLE
1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-file-dl",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Download files to a specified folder and notify the user while the download is happening and when the download finishes",
   "keywords": [
     "expo",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,11 @@ function initBaseNotificationRequestInput(filename: string, channelId: string): 
       ...baseNotificationRequestInput.content,
       title: filename
     },
-    trigger: { channelId }
+    trigger: { 
+      channelId,
+      seconds: 1,
+      repeats: false
+    }
   };
   return baseNotificationRI;
 }


### PR DESCRIPTION
Fixes an issue where iOS notifications weren't being triggered because [ChannelAwareTriggerInput](https://docs.expo.io/versions/v39.0.0/sdk/notifications/#channelawaretriggerinput) doesn't work on iOS. To fix this I added a [TimeIntervalTriggerInput](https://docs.expo.io/versions/v39.0.0/sdk/notifications/#timeintervaltriggerinput)